### PR TITLE
fix: corrige build da página PatoTech

### DIFF
--- a/app/patotech/page.tsx
+++ b/app/patotech/page.tsx
@@ -249,25 +249,22 @@ const FeaturedCourseCard = ({ course }: { course: FeaturedCourse }) => {
         <p className="mt-3 flex-1 text-sm leading-6 text-slate-600">{course.description}</p>
 
         <div className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
-          <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-            <span className="flex items-center gap-2 font-bold text-slate-900">
-              <CalendarDays className="h-4 w-4 text-cello-700" />
-              Matrículas
-            </span>
-            <p className="mt-1 text-slate-600">{course.enrollmentDate}</p>
-          </div>
-        </section>
+  <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+    <span className="flex items-center gap-2 font-bold text-slate-900">
+      <CalendarDays className="h-4 w-4 text-cello-700" />
+      Matrículas
+    </span>
+    <p className="mt-1 text-slate-600">{course.enrollmentDate}</p>
+  </div>
 
-        <CourseHeader
-          id="20"
-          image="/assets/images/cursos/htmlcss.jpeg"
-          title="HTML E CSS - CRIAÇÃO DE WEBSITES "
-          description="Desenvolver habilidades fundamentais, entender como a web é construída e visualizar-se em uma carreira na área de desenvolvimento front-end. Compreender como as páginas ganham estrutura com HTML, estilo com CSS e como essas linguagens dão vida a sites modernos e acessíveis.
-          Palavra passe: PARCERIAPATOBRANCO"
-          partners="SMCTI e SENAC"
-          link="https://www.pr.senac.br/cursos/?uep=9&tc=202600084"
-          date="07/07/2026 a 04/08/2026"
-        />
+  <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+    <span className="flex items-center gap-2 font-bold text-slate-900">
+      <CalendarDays className="h-4 w-4 text-cello-700" />
+      Início do curso
+    </span>
+    <p className="mt-1 text-slate-600">{course.startDate}</p>
+  </div>
+</div>
 
         <div className="mt-4 flex flex-wrap gap-2">
           <span className="inline-flex items-center gap-2 rounded-lg bg-cyan-50 px-3 py-2 text-xs font-bold text-cello-800">


### PR DESCRIPTION
correção de um bug que causou o erro de build do site.

explicação do problema e forma de resolução utilizada:
O problema ocorreu durante o deploy da branch de alteração de layout da aba PatoTech. O Google Cloud Build falhou porque o Next.js encontrou um erro de sintaxe no arquivo app/patotech/page.tsx, dentro do componente FeaturedCourseCard.

A causa foi um trecho de JSX quebrado: havia um fechamento incorreto com </section> dentro do card, além de um componente <CourseHeader /> colado no meio da estrutura do FeaturedCourseCard. Isso deixou o JSX inválido e impediu o comando npm run build de concluir.

A solução foi remover o bloco indevido do <CourseHeader />, substituir o fechamento incorreto e reorganizar corretamente as divs do card, mantendo os campos de Matrículas e Início do curso dentro da mesma grade. Após essa correção, a estrutura JSX ficou válida novamente, permitindo que o build e o deploy avancem corretamente.